### PR TITLE
Status map: include "Abnormal Exit".

### DIFF
--- a/layout/index.slim
+++ b/layout/index.slim
@@ -206,6 +206,8 @@ html
                       span.label.label-default = mutation.status
                     - if mutation.crashed?
                       span.label.label-danger = mutation.status
+                    - if mutation.abnormal_exit?
+                      span.label.label-danger = mutation.status
                     - if mutation.dryRun?
                       span.label.label-info = mutation.status
 

--- a/lib/models/mutation_result.rb
+++ b/lib/models/mutation_result.rb
@@ -51,8 +51,12 @@ class MutationResult
     result.status.equal? 4
   end
 
-  def dryRun?
+  def abnormal_exit?
     result.status.equal? 5
+  end
+
+  def dryRun?
+    result.status.equal? 6
   end
 
   def status
@@ -66,6 +70,8 @@ class MutationResult
     when 4
       "Crashed"
     when 5
+      "Abnormal Exit"
+    when 6
       "Dry Run"
     else
       "unknown"


### PR DESCRIPTION
Updates to the recent status map:

```cpp
enum ExecutionStatus {
  Invalid = 0,
  Failed,
  Passed,
  Timedout,
  Crashed,
  AbnormalExit,
  DryRun
};
```